### PR TITLE
[Feat/#22] 마이페이지 사용자 서비스 이용 내역, 면허 정보, 계정 관리 UI 구현

### DIFF
--- a/src/pages/myPage/MyPage.js
+++ b/src/pages/myPage/MyPage.js
@@ -5,6 +5,7 @@ import MyPageUserInfo from "./myPageUserInfo/MyPageUserInfo";
 import MyPagePreferCar from "./myPagePreferCar/MyPagePreferCar";
 import MyPageRecord from "./myPageRecord/MyPageRecord";
 import MyPageLicense from "./myPageLicense/MyPageLicense";
+import MyPageAccount from "./myPageAccount/myPageAccount";
 
 function MyPage() {
   // 사용자의 예약 정보 객체
@@ -60,6 +61,8 @@ function MyPage() {
         <MyPageRecord recordInfo={recordInfo} />
         {/* 사용자 면허 정보 */}
         <MyPageLicense licenseInfo={licenseInfo} />
+        {/* 사용자 계정 관리 */}
+        <MyPageAccount />
       </div>
     </>
   );

--- a/src/pages/myPage/MyPage.js
+++ b/src/pages/myPage/MyPage.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import MyPageResvCardView from "./myPageResvCardView/MyPageResvCardView";
 import MyPageUserInfo from "./myPageUserInfo/MyPageUserInfo";
 import MyPagePreferCar from "./myPagePreferCar/MyPagePreferCar";
+import MyPageRecord from "./myPageRecord/MyPageRecord";
 
 function MyPage() {
   // 사용자의 예약 정보 객체
@@ -28,6 +29,16 @@ function MyPage() {
     구동기: ["자동", "수동"],
     최소인원: ["5인승", "7인승", "11인승"],
   });
+  // 사용자 내역 정보
+  let [recordInfo, setRecordInfo] = useState({
+    point: 1000,
+    recent: [
+      ["차1", "11일 1111", "11111", "11111"],
+      ["차2", "22이 2222", "22222", "22222"],
+      ["차3", "33삼 3333", "33333", "33333"],
+      ["차5", "55오 5555", "55555", "55555"],
+    ],
+  });
   return (
     <>
       <div className="w-[1200px] h-fit mx-auto pt-36">
@@ -37,6 +48,8 @@ function MyPage() {
         <MyPageUserInfo userInfo={userInfo} />
         {/* 사용자 선호 차량 조건 */}
         <MyPagePreferCar preferInfo={preferInfo} />
+        {/* 사용자 이용 내역 */}
+        <MyPageRecord recordInfo={recordInfo} />
       </div>
     </>
   );

--- a/src/pages/myPage/MyPage.js
+++ b/src/pages/myPage/MyPage.js
@@ -4,6 +4,7 @@ import MyPageResvCardView from "./myPageResvCardView/MyPageResvCardView";
 import MyPageUserInfo from "./myPageUserInfo/MyPageUserInfo";
 import MyPagePreferCar from "./myPagePreferCar/MyPagePreferCar";
 import MyPageRecord from "./myPageRecord/MyPageRecord";
+import MyPageLicense from "./myPageLicense/MyPageLicense";
 
 function MyPage() {
   // 사용자의 예약 정보 객체
@@ -39,6 +40,13 @@ function MyPage() {
       ["차5", "55오 5555", "55555", "55555"],
     ],
   });
+  // 사용자 면허 정보
+  let [licenseInfo, setLicenseInfo] = useState({
+    종류: "1종 보통",
+    번호: "00-00-000000-00",
+    발급일자: "2023-01-01",
+    만료일자: "2023-12-31",
+  });
   return (
     <>
       <div className="w-[1200px] h-fit mx-auto pt-36">
@@ -50,6 +58,8 @@ function MyPage() {
         <MyPagePreferCar preferInfo={preferInfo} />
         {/* 사용자 이용 내역 */}
         <MyPageRecord recordInfo={recordInfo} />
+        {/* 사용자 면허 정보 */}
+        <MyPageLicense licenseInfo={licenseInfo} />
       </div>
     </>
   );

--- a/src/pages/myPage/myPageAccount/myPageAccount.js
+++ b/src/pages/myPage/myPageAccount/myPageAccount.js
@@ -1,0 +1,47 @@
+import React from "react";
+
+function MyPageAccount() {
+  return (
+    <>
+      <div className="w-full mt-20 h-fit">
+        {/* 계정 관리 타이틀 */}
+        <div className="flex items-center justify-between w-full h-12">
+          <div className="flex items-center justify-center w-[15%] h-full text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
+            계정 관리
+          </div>
+        </div>
+        {/* 계정 관리 */}
+        <div className="flex flex-col justify-around items-center w-full h-[25vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
+          <div className="flex flex-col justify-between w-full h-1/3">
+            <div className="flex justify-between w-full h-[60%]">
+              {/* 회원 탈퇴 타이틀 */}
+              <div className="flex items-center justify-center text-xl font-bold text-slate-400">
+                회원 탈퇴
+              </div>
+              {/* 탈퇴 버튼 */}
+              <div className="w-[15%] flex justify-center items-center text-xl font-bold border-blue-300 border-4 rounded-md bg-slate-100 text-rose-500">
+                탈퇴하기
+              </div>
+            </div>
+            <hr className="w-full border-black" />
+          </div>
+          <div className="flex flex-col justify-between w-full h-1/3">
+            <div className="flex justify-between w-full h-[60%]">
+              {/* 로그아웃 타이틀 */}
+              <div className="flex items-center justify-center text-xl font-bold text-slate-400">
+                로그아웃
+              </div>
+              {/* 로그아웃 버튼 */}
+              <div className="w-[15%] flex justify-center items-center text-xl font-bold border-blue-300 border-4 rounded-md bg-slate-100 text-rose-500">
+                로그아웃
+              </div>
+            </div>
+            <hr className="w-full border-black" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MyPageAccount;

--- a/src/pages/myPage/myPageLicense/MyPageLicense.js
+++ b/src/pages/myPage/myPageLicense/MyPageLicense.js
@@ -1,0 +1,36 @@
+import React from "react";
+import Item from "./internalComponents/Item";
+
+/**
+ *
+ * @param {Object} licenseInfo 최상위 컴포넌트에서 받아온 사용자의 면허 정보 객체
+ * @returns
+ */
+function MyPageUserInfo(props) {
+  let titles = Object.keys(props.licenseInfo);
+
+  return (
+    <>
+      <div className="w-full mt-20 h-fit">
+        {/* 면허 정보 타이틀 */}
+        <div className="flex items-center justify-between w-full h-12">
+          <div className="flex items-center justify-center w-[15%] h-full text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
+            면허 정보
+          </div>
+          {/* 새로운 면허 인증 버튼 */}
+          <div className="flex items-center justify-center w-[15%] h-full text-xl font-bold bg-slate-100 border-slate-400 border-4 rounded-md">
+            새 면허 인증
+          </div>
+        </div>
+        {/* 기본 정보들 */}
+        <div className="flex flex-col justify-around items-center w-full h-[60vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
+          {titles.map((title) => {
+            return <Item title={title} content={props.licenseInfo[title]} />;
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MyPageUserInfo;

--- a/src/pages/myPage/myPageLicense/internalComponents/Item.js
+++ b/src/pages/myPage/myPageLicense/internalComponents/Item.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+/**
+ *
+ * @param {string} props.title 부모의 부모부터 받아온 어떤 정보인지 title
+ * @param {string} props.content 부모의 부모부터 받아온 title 에 맞는 내용
+ * @returns
+ */
+function Item(props) {
+  return (
+    <>
+      <div className="flex flex-col justify-between w-full h-1/6">
+        {/* 정보 타이틀 */}
+        <div className="text-xl font-bold text-slate-400">{props.title}</div>
+        {/* 정보 내용 */}
+        <div className="text-xl font-bold">{props.content}</div>
+        <hr className="w-full border-black" />
+      </div>
+    </>
+  );
+}
+
+export default Item;

--- a/src/pages/myPage/myPageRecord/MyPageRecord.js
+++ b/src/pages/myPage/myPageRecord/MyPageRecord.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Point from "./internalComponents/Point";
+import Reservation from "./internalComponents/Reservation";
+import Recent from "./internalComponents/Recent";
+
+/**
+ *
+ * @param {object} props.recordInfo 부모에게 받아와 자식에게 전해줄 각종 내역 정보 객체
+ * @returns
+ */
+function MyPageRecord(props) {
+  return (
+    <>
+      <div className="w-full mt-20 h-fit">
+        {/* 내역 조회 타이틀 */}
+        <div className="flex items-center justify-center w-[15%] h-12 text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
+          내역 조회
+        </div>
+        {/* 각종 내역들 */}
+        <div className="flex flex-col items-center justify-between w-full pt-5 mt-5 bg-white border-4 rounded-md px-28 h-fit border-slate-400">
+          <Reservation />
+          <Point point={props.recordInfo["point"]} />
+          <Recent recent={props.recordInfo["recent"]} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MyPageRecord;

--- a/src/pages/myPage/myPageRecord/internalComponents/CarCard.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/CarCard.js
@@ -1,0 +1,40 @@
+import React from "react";
+import ExCar from "../../../../assets/ExCar.png";
+
+/**
+ *
+ * @param {array} props.carInfo 부모에게서 받아온 사용자가 최근 본 특정 차량의 정보 객체
+ * @returns
+ */
+function CarCard(props) {
+  return (
+    <>
+      <div className="flex items-center justify-center w-1/3 rounded-lg h-1/2">
+        <div className="w-[90%] h-[90%] bg-sky-100 rounded-md flex flex-col justify-around items-center">
+          {/* 차량의 사진 */}
+          <img src={ExCar} alt="ExCar" className="object-contain h-1/2"></img>
+          {/* 차종, 차량 번호*/}
+          <div className="w-[80%] h-[10%] flex justify-around">
+            <div className="flex items-center justify-center h-full font-bold bg-blue-300 rounded-md w-fit min-w-[30%] text-sm">
+              {props.carInfo[0]}
+            </div>
+            <div className="flex items-center justify-center h-full font-bold bg-blue-300 rounded-md w-fit min-w-[50%] text-sm">
+              {props.carInfo[1]}
+            </div>
+          </div>
+          {/* 총 주행 거리, 1일 렌트 비용 */}
+          <div className="w-[80%] h-[10%] flex justify-around">
+            <div className="h-full bg-blue-300 rounded-md w-fit min-w-[50%] flex justify-center items-center font-bold text-sm">
+              총 {props.carInfo[2]}km
+            </div>
+            <div className="h-full bg-amber-500 rounded-md min-w-[40%] w-fit flex justify-center items-center font-bold text-sm">
+              {props.carInfo[3]}원
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default CarCard;

--- a/src/pages/myPage/myPageRecord/internalComponents/Point.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Point.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+/**
+ *
+ * @param {number} props.point 부모에게서 받아온 사용자가 현재 보유 중인 포인트
+ * @returns
+ */
+function Point(props) {
+  return (
+    <>
+      <div className="flex flex-col justify-around items-center w-full h-[15vh] mt-3">
+        <div className="flex items-center justify-between w-full h-[60%]">
+          <div className="flex flex-col justify-around h-full text-2xl font-bold">
+            {/* 내역 타이틀 */}
+            <div className="flex items-center text-slate-400">
+              포인트 적립/사용 내역
+            </div>
+            {/* 현재 사용자 보유 중인 포인트 */}
+            <div className="flex items-center text-black">
+              현재 포인트 : {props.point}
+            </div>
+          </div>
+          {/* 내역 조회 버튼 */}
+          <div className="bg-slate-100 border-4 rounded-md border-blue-300 h-[55%] w-[15%] flex justify-center items-center font-bold text-xl">
+            포인트 내역
+          </div>
+        </div>
+        <hr className="w-full border-black"></hr>
+      </div>
+    </>
+  );
+}
+
+export default Point;

--- a/src/pages/myPage/myPageRecord/internalComponents/Recent.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Recent.js
@@ -1,0 +1,30 @@
+import React from "react";
+import CarCard from "./CarCard";
+
+/**
+ *
+ * @param {array} props.recent 부모에게서 받아온 사용자가 최근 본 차량 리스트
+ * @returns
+ */
+function Recent(props) {
+  return (
+    <>
+      <div className="w-full h-[55vh] mt-3">
+        <div className="flex flex-col justify-around w-full h-full">
+          {/* 내역 타이틀 */}
+          <div className="flex items-center text-2xl font-bold text-slate-400">
+            최근 본 차량 조회
+          </div>
+          {/* 최근 본 차량 리스트 */}
+          <div className="border-4 rounded-md border-blue-300 h-[90%] w-full flex flex-wrap overflow-y-scroll">
+            {props.recent.map((carInfo) => {
+              return <CarCard carInfo={carInfo} />;
+            })}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Recent;

--- a/src/pages/myPage/myPageRecord/internalComponents/Reservation.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Reservation.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+function Reservation() {
+  return (
+    <>
+      <div className="flex flex-col justify-around items-center w-full h-[10vh]">
+        <div className="flex items-center justify-between w-full h-1/2">
+          {/* 내역 타이틀 */}
+          <div className="flex items-center text-2xl font-bold text-slate-400">
+            예약 내역 조회
+          </div>
+          {/* 내역 조회 버튼 */}
+          <div className="bg-slate-100 border-4 rounded-md border-blue-300 h-full w-[15%] flex justify-center items-center font-bold text-xl">
+            예약 내역
+          </div>
+        </div>
+        <hr className="w-full border-black"></hr>
+      </div>
+    </>
+  );
+}
+
+export default Reservation;

--- a/src/pages/myPage/myPageUserInfo/internalComponents/ChangeNickname.js
+++ b/src/pages/myPage/myPageUserInfo/internalComponents/ChangeNickname.js
@@ -5,7 +5,7 @@ import React from "react";
  * @param {string} props.title 부모의 부모부터 받아온 어떤 정보인지 title
  * @param {string} props.content 부모의 부모부터 받아온 title 에 맞는 내용
  * @param {string} props.infoType 부모의 부모에게 받아온 title 에 따른 css
- * @param {string} props.setType 부모에게 받아온 현재 상황에 따른 type useState setter
+ * @param {setter} props.setType 부모에게 받아온 현재 상황에 따른 type useState setter
  * @returns
  */
 function ChangeNickname(props) {

--- a/src/pages/myPage/myPageUserInfo/internalComponents/DefaultItem.js
+++ b/src/pages/myPage/myPageUserInfo/internalComponents/DefaultItem.js
@@ -5,7 +5,7 @@ import React from "react";
  * @param {string} props.title 부모의 부모부터 받아온 어떤 정보인지 title
  * @param {string} props.content 부모의 부모부터 받아온 title 에 맞는 내용
  * @param {string} props.infoType 부모의 부모에게 받아온 title 에 따른 css
- * @param {string} props.setType 부모에게 받아온 현재 상황에 따른 type useState setter
+ * @param {setter} props.setType 부모에게 받아온 현재 상황에 따른 type useState setter
  * @returns
  */
 function DefaultItem(props) {


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

- 사용자의 서비스 이용 내역들을 볼 수 있는 UI 구현
- 사용자의 면허 정보를 볼 수 있는 UI 구현
- 사용자가 계정을 탈퇴하거나 로그아웃할 수 있는 UI 구현 

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

### 서비스 이용 내역 UI 구현
사용자들은 유렌카 서비스를 이용하면서 3가지의 내역들에 대해 마이페이지에서 조회해볼 수 있다.
<br>
첫 번째로는 사용자의 과거에 이용했던 예약들에 대한 내역이다. 현재에는 직접 정보들을 볼 수 있는 UI 가 아닌 조회를 시작할 수 있는 트리거만을 구현해두었기에 타이틀과 버튼만이 구현되어있다.
```javascript
// Reservation.js
{/* 내역 타이틀 */}
          <div className="flex items-center text-2xl font-bold text-slate-400">
            예약 내역 조회
          </div>
          {/* 내역 조회 버튼 */}
          <div className="bg-slate-100 border-4 rounded-md border-blue-300 h-full w-[15%] flex justify-center items-center font-bold text-xl">
            예약 내역
          </div>
```
<br>

두 번째로는 사용자가 포인트를 사용하거나 적립받은 내역이다. 역시 조회를 시작할 수 있는 트리거만을 구현해두었다. 다만, 현재 사용자가 보유 중인 포인트만큼은 바로 볼 수 있도록 하는 것이 좋다고 판단하여 현재 보유 중인 포인트는 바로 확인할 수 있다.
```javascript
// Point.js
<div className="flex flex-col justify-around h-full text-2xl font-bold">
            {/* 내역 타이틀 */}
            <div className="flex items-center text-slate-400">
              포인트 적립/사용 내역
            </div>
            {/* 현재 사용자 보유 중인 포인트 */}
            <div className="flex items-center text-black">
              현재 포인트 : {props.point}
            </div>
</div>
          {/* 내역 조회 버튼 */}
<div className="bg-slate-100 border-4 rounded-md border-blue-300 h-[55%] w-[15%] flex justify-center items-center font-bold text-xl">
            포인트 내역
</div>
```
<br>

마지막 세 번째로는 사용자가 최근에 조회했던 차량들에 대한 내역이다. 이번에는 위의 두 경우들과는 달리 직접 정보들을 바로 확인해볼 수 있다. 다만, 전체 상세 정보들을 조회하는 것이 아닌 간략화된 정보들을 차량마다 카드뷰로 구현하여 보여지게 된다.
```javascript
// Recent.js
{/* 내역 타이틀 */}
          <div className="flex items-center text-2xl font-bold text-slate-400">
            최근 본 차량 조회
          </div>
          {/* 최근 본 차량 리스트 */}
          <div className="border-4 rounded-md border-blue-300 h-[90%] w-full flex flex-wrap overflow-y-scroll">
            {props.recent.map((carInfo) => {
              return <CarCard carInfo={carInfo} />;
            })}
          </div>
```
할당된 공간 내에서 최근에 조회했던 차량들에 대한 정보들을 간략화하여 CarCard 라는 컴포넌트를 이용하여 보여주게 된다. 
```javascript
// CarCard.js
{/* 차량의 사진 */}
          <img src={ExCar} alt="ExCar" className="object-contain h-1/2"></img>
          {/* 차종, 차량 번호*/}
          <div className="w-[80%] h-[10%] flex justify-around">
            <div className="flex items-center justify-center h-full font-bold bg-blue-300 rounded-md w-fit min-w-[30%] text-sm">
              {props.carInfo[0]}
            </div>
            <div className="flex items-center justify-center h-full font-bold bg-blue-300 rounded-md w-fit min-w-[50%] text-sm">
              {props.carInfo[1]}
            </div>
          </div>
          {/* 총 주행 거리, 1일 렌트 비용 */}
          <div className="w-[80%] h-[10%] flex justify-around">
            <div className="h-full bg-blue-300 rounded-md w-fit min-w-[50%] flex justify-center items-center font-bold text-sm">
              총 {props.carInfo[2]}km
            </div>
            <div className="h-full bg-amber-500 rounded-md min-w-[40%] w-fit flex justify-center items-center font-bold text-sm">
              {props.carInfo[3]}원
            </div>
          </div>
```
각 카드뷰들에는 5가지의 정보들을 확인할 수 있다. 우선, 조회한 차량의 사진을 확인할 수 있다. 제한적인 공간만 제공되는만큼 한눈에 볼 수 있도록 사진이 차지하는 비율을 카드뷰 높이의 50% 정도를 차지하도록 지정하였다. 그 후, 차종, 차량 번호, 총 주행 거리, 1일 렌트 비용 4가지의 기본적인 차량이 정보들을 태그의 형태로 보여주게 된다. 이때, 가격은 차량을 예약하고 렌트하는데에 있어 중요한 요소이기 때문에 눈에 잘 띄도록 배경색을 달리하여주었다.
<br>

### 사용자 면허 정보 UI 구현
렌트카 서비스를 이용하기 위해서 사용자는 면허증을 등록하여야만 한다. 그래서 등록한 면허의 정보들을 보여줄 수 있는 UI 가 구현된다. 기존에 등록한 정보들을 조회할 수 있는 영역은 이전에 구현했던 사용자의 기본 정보를 볼 수 있는 UI 를 구현할 때 했던 방식과 매우 유사하다. 특히, 면허 정보의 경우 닉네임과 같은 특별히 다르게 UI 를 처리해주어야하는 부분이 없기에 더 단순하게 구현되었다.
```javascript
// MyPageLicense.js
{/* 기본 정보들 */}
<div className="flex flex-col justify-around items-center w-full h-[60vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
          {titles.map((title) => {
            return <Item title={title} content={props.licenseInfo[title]} />;
          })}
</div>
```
사용자의 기본 정보 UI 에서는 닉네임이냐 아니냐, 닉네임 조회냐 닉네임 변경이냐에 따라 다른 UI 들을 구현하였으나 면허 정보의 경우 타이틀과 타이틀에 해당하는 정보들을 담는 컴포넌트 하나면 충분하다. 이 역할을 기본 정보 UI 에서는 DefaultItem 컴포넌트가 수행했고 면허 정보 UI 에서는 Item 컴포넌트가 수행하게 된다.
```javascript
// Item.js
{/* 정보 타이틀 */}
<div className="text-xl font-bold text-slate-400">{props.title}</div>
{/* 정보 내용 */}
<div className="text-xl font-bold">{props.content}</div>
```
위처럼 타이틀과 타이틀에 해당하는 내용만을 보여주게 된다. 그러나 주의할 점은 면허의 정보는 언제든지 변경될 수 있다. 따라서 면허증을 새로 등록 혹은 인증할 수 있는 UI 가 요구된다. 그렇기에 그 과정을 진행하고자하는 트리거인 버튼을 추가적으로 구현하였다. 실제 과정을 진행하는 동안을 보여주는 UI 는 추후에 구현될 예정이다.
```javascript
// MyPageLicense.js
{/* 새로운 면허 인증 버튼 */}
<div className="flex items-center justify-center w-[15%] h-full text-xl font-bold bg-slate-100 border-slate-400 border-4 rounded-md">
            새 면허 인증
</div>
```
<br>

### 사용자가 계정을 탈퇴하거나 로그아웃할 수 있는 UI 구현
마이페이지에서 사용자가 수행할 수 있는 기능들 중 마지막이 계정 관리이다. 현재 계정 관리에는 회원 탈퇴, 로그아웃 두가지가 수행될 수 있다. 그래서 두 가지에 대한 UI 를 구현하였다. 이 역시 기존의 타이틀과 내용을 보여주는 틀에서 크게 벗어나지 않는다. 차이점이라면, 기존의 내용들은 단순히 텍스트의 형태였으나, 여기서는 타이틀에 대한 기능을 수행할 수 있는 트리거인 버튼을 보여주게된다. 특히, 계정 관리의 경우 사용자가 유렌카 시스템 서비스를 이용하는 데에 있어 중요한 요소이기에, 붉은 색 텍스트를 버튼 내부에 배치함으로써 눈에 잘 부각되도록 하였다.
```javascript
// MyPageAccount.js
{/* 회원 탈퇴 타이틀 */}
<div className="flex items-center justify-center text-xl font-bold text-slate-400">
                회원 탈퇴
</div>
{/* 탈퇴 버튼 */}
<div className="w-[15%] flex justify-center items-center text-xl font-bold border-blue-300 border-4 rounded-md bg-slate-100 text-rose-500">
                탈퇴하기
</div>

...

{/* 로그아웃 타이틀 */}
<div className="flex items-center justify-center text-xl font-bold text-slate-400">
                로그아웃
</div>
{/* 로그아웃 버튼 */}
<div className="w-[15%] flex justify-center items-center text-xl font-bold border-blue-300 border-4 rounded-md bg-slate-100 text-rose-500">
                로그아웃
</div>
```

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 사용자의 예약 내역 UI 가 제대로 적용되었는지 확인
- [x] 사용자의 포인트 사용/적립 내역 UI 제대로 적용되었는지 확인
- [x] 사용자가 현재 보유 중인 포인트가 제대로 보여지는지 확인
- [x] 사용자가 최근 본 차량 조회 UI 제대로 적용되었는지 확인
- [x] 각 차량에 대한 정보들을 보여주는 카드뷰가 의도한대로 표현되는지 확인
- [x] 계정 관리 UI 가 제대로 적용되었는지 확인
- [x] 버튼의 텍스트가 붉은 색으로 제대로 표현되는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

각종 내역들을 확인할 수 있도록 UI 들이 보여지는 것을 확인할 수 있다. 포인트 내역에는 현재 보유 중인 포인트가 제대로 보여지고 있으며, 최근 본 차량 내역에는 차량들별로 정보들이 카드뷰 내에서 제대로 보여지는 것을 확인할 수 있다.
<img width="726" alt="스크린샷 2023-05-25 오후 4 52 00" src="https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/288441ff-e579-4f98-bfbe-683ae3ad1ed4">
<br>

면허 정보들이 제대로 보여지고 있으며, 새 면허 인증 버튼 또한 의도한 위치에 제대로 보여지고 있다.
<img width="728" alt="스크린샷 2023-05-25 오후 4 52 11" src="https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/097ba300-9c6f-4196-a2d0-73d2ad96b2aa">
<br>

계정 관리 2가지에 대한 UI 가 제대로 보여지고 있으며, 버튼 내의 텍스트의 경우엔 의도한대로 눈에 잘 띄도록 붉은색으로 제대로 보여지고 있다.
<img width="729" alt="스크린샷 2023-05-25 오후 4 52 20" src="https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/1ff842e3-aaf5-4579-a570-a852ddc23ec7">

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #22 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

- TailwindCSS documents : https://tailwindcss.com/docs/
- CSS flex : https://studiomeal.com/archives/197
- CSS grid : https://studiomeal.com/archives/533
- 
<!-- 자신이 참조한 정보의 출처를 적는다. -->
