### PR TITLE
[Refactor/#26] 마이페이지 컨텐츠 UI 세로 비율 조정

### DIFF
--- a/src/pages/myPage/myPageAccount/myPageAccount.js
+++ b/src/pages/myPage/myPageAccount/myPageAccount.js
@@ -3,7 +3,7 @@ import React from "react";
 function MyPageAccount() {
   return (
     <>
-      <div className="w-full mt-20 h-fit">
+      <div className="w-full mt-20 h-[350px]">
         {/* 계정 관리 타이틀 */}
         <div className="flex items-center justify-between w-full h-12">
           <div className="flex items-center justify-center w-[15%] h-full text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
@@ -11,7 +11,7 @@ function MyPageAccount() {
           </div>
         </div>
         {/* 계정 관리 */}
-        <div className="flex flex-col justify-around items-center w-full h-[25vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
+        <div className="flex flex-col justify-around items-center w-full h-[80%] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
           <div className="flex flex-col justify-between w-full h-1/3">
             <div className="flex justify-between w-full h-[60%]">
               {/* 회원 탈퇴 타이틀 */}

--- a/src/pages/myPage/myPageLicense/MyPageLicense.js
+++ b/src/pages/myPage/myPageLicense/MyPageLicense.js
@@ -11,7 +11,7 @@ function MyPageUserInfo(props) {
 
   return (
     <>
-      <div className="w-full mt-20 h-fit">
+      <div className="w-full mt-20 h-[70vh] min-h-[720px]">
         {/* 면허 정보 타이틀 */}
         <div className="flex items-center justify-between w-full h-12">
           <div className="flex items-center justify-center w-[15%] h-full text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
@@ -23,7 +23,7 @@ function MyPageUserInfo(props) {
           </div>
         </div>
         {/* 기본 정보들 */}
-        <div className="flex flex-col justify-around items-center w-full h-[60vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
+        <div className="flex flex-col justify-around items-center w-full h-[90%] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
           {titles.map((title) => {
             return <Item title={title} content={props.licenseInfo[title]} />;
           })}

--- a/src/pages/myPage/myPagePreferCar/MyPagePreferCar.js
+++ b/src/pages/myPage/myPagePreferCar/MyPagePreferCar.js
@@ -9,13 +9,13 @@ import PreferOptions from "./internalComponents/PreferOptions";
 function MyPagePreferCar(props) {
   return (
     <>
-      <div className="w-full mt-20 h-fit">
+      <div className="w-full h-[45vh] min-h-[450px] mt-20">
         {/* 선호 차량 타이틀 */}
         <div className="flex items-center justify-center w-[15%] h-12 text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
           선호 차량
         </div>
         {/* 선호 차량 옵션들 */}
-        <div className="flex flex-col justify-between items-center w-full h-[35vh] bg-white border-4 rounded-md border-slate-400 mt-5 px-28 py-10">
+        <div className="flex flex-col justify-between items-center w-full h-[80%] bg-white border-4 rounded-md border-slate-400 mt-5 px-28 py-10">
           {/* 각 옵션 제목 & 목록 */}
           <PreferOptions preferInfo={props.preferInfo} />
           {/* 변경 저장 버튼 */}

--- a/src/pages/myPage/myPageRecord/MyPageRecord.js
+++ b/src/pages/myPage/myPageRecord/MyPageRecord.js
@@ -11,13 +11,13 @@ import Recent from "./internalComponents/Recent";
 function MyPageRecord(props) {
   return (
     <>
-      <div className="w-full mt-20 h-fit">
+      <div className="w-full mt-20 h-[980px]">
         {/* 내역 조회 타이틀 */}
         <div className="flex items-center justify-center w-[15%] h-12 text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
           내역 조회
         </div>
         {/* 각종 내역들 */}
-        <div className="flex flex-col items-center justify-between w-full pt-5 mt-5 bg-white border-4 rounded-md px-28 h-fit border-slate-400">
+        <div className="flex flex-col items-center justify-between w-full pt-5 mt-5 bg-white border-4 rounded-md px-28 h-[920px] border-slate-400">
           <Reservation />
           <Point point={props.recordInfo["point"]} />
           <Recent recent={props.recordInfo["recent"]} />

--- a/src/pages/myPage/myPageRecord/internalComponents/Point.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Point.js
@@ -8,7 +8,7 @@ import React from "react";
 function Point(props) {
   return (
     <>
-      <div className="flex flex-col justify-around items-center w-full h-[15vh] mt-3">
+      <div className="flex flex-col justify-around items-center w-full h-[15%] mt-3">
         <div className="flex items-center justify-between w-full h-[60%]">
           <div className="flex flex-col justify-around h-full text-2xl font-bold">
             {/* 내역 타이틀 */}

--- a/src/pages/myPage/myPageRecord/internalComponents/Recent.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Recent.js
@@ -9,7 +9,7 @@ import CarCard from "./CarCard";
 function Recent(props) {
   return (
     <>
-      <div className="w-full h-[55vh] mt-3">
+      <div className="w-full h-[70%] mt-3">
         <div className="flex flex-col justify-around w-full h-full">
           {/* 내역 타이틀 */}
           <div className="flex items-center text-2xl font-bold text-slate-400">

--- a/src/pages/myPage/myPageRecord/internalComponents/Reservation.js
+++ b/src/pages/myPage/myPageRecord/internalComponents/Reservation.js
@@ -3,7 +3,7 @@ import React from "react";
 function Reservation() {
   return (
     <>
-      <div className="flex flex-col justify-around items-center w-full h-[10vh]">
+      <div className="flex flex-col justify-around items-center w-full h-[10%]">
         <div className="flex items-center justify-between w-full h-1/2">
           {/* 내역 타이틀 */}
           <div className="flex items-center text-2xl font-bold text-slate-400">

--- a/src/pages/myPage/myPageUserInfo/MyPageUserInfo.js
+++ b/src/pages/myPage/myPageUserInfo/MyPageUserInfo.js
@@ -18,13 +18,13 @@ function MyPageUserInfo(props) {
 
   return (
     <>
-      <div className="w-full mt-20 h-fit">
+      <div className="w-full h-[70vh] min-h-[720px] mt-20">
         {/* 기본 정보 타이틀 */}
         <div className="flex items-center justify-center w-[15%] h-12 text-xl font-bold border-2 border-dashed rounded-md border-slate-400">
           기본 정보
         </div>
         {/* 기본 정보들 */}
-        <div className="flex flex-col justify-around items-center w-full h-[60vh] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
+        <div className="flex flex-col justify-around items-center w-full h-[90%] bg-white border-4 rounded-md border-slate-400 px-28 py-5 mt-5">
           {titles.map((title) => {
             return title !== "닉네임" ? (
               // 닉네임이 아닌 경우는 기본 틀 (변경 버튼이 없음)


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

- 마이페이지에 노출될 컨텐츠들의 세로 비율을 조정
- 모든 컨텐츠들의 최소 세로 크기를 16:9 FHD 해상도를 기준으로 지정
 - 각 컨텐츠 별 내부 요소들의 세로를 vh 단위가 아닌 퍼센트 혹은 고정된 픽셀 값


<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

> 세로 비율 조정의 이유...

모든 컨텐츠들 최상위 컨테이너의 높이는 모두 fit-content 로 지정되어있었다. 따라서, 내부의 요소들이 차지하는 높이들에 따라 최종 컨텐츠의 높이가 결정되었다. 그 과정에서 특정 요소들에는 뷰포트와 연관된 vh 단위가 섞여있었다.
뷰포트를 단위로 설정했을 때 주의할 점은 브라우저 혹은 웹이 띄워질 어플리케이션의 가로 비율을 사용자가 줄이게 된다면 보여지는 컨텐츠들 UI 들이 줄어드는 뷰포트에 맞춰 줄어들거나 깨지게 된다. 이는 곧 사용자에게 서비스 이용의 불편함을 주게 된다. 따라서, 전체 컨텐츠들의 세로 비율을 조정하도록 결정하였다.

### 세로 비율 조정 방식
- 작업하는 환경인 16:9 FHD 해상도에 맞춰 초기 높이를 직접 지정 ( 여기서는 vh 단위도 지정 가능 )
- vh 혹은 퍼센트와 같이 유동적인 변화가 이뤄질 수 있는 경우에는 minimum height 을 지정

### 비율 조정
컨텐츠들의 비율 조정 순서는 마이페이지에서 보여질 순서를 기준으로 조정되었다.

사용자의 기본 정보를 보여주는 UI 경우에는 내부 요소들이 텍스트가 대부분이며 각자 고정된 크기를 가지고 있기에 전체 높이를 뷰포트 단위로 지정해주었다. 대신, 사용자에게 정보들을 보는데에 있어 불편하지 않도록 최소의 높이를 지정하여주었다.
```javascript
// MyPageUserInfo.js
<div className="w-full h-[70vh] min-h-[720px] mt-20">
```
<br>

사용자의 선호 차량 옵션을 보여주는 UI 경우에는 내부 요소들이 가로로 길게 뻗어있는 라벨, 목록, 버튼이 대부분이기에 너비의 중요도가 더 크다.따라서, 선호 차량 옵션의 경우에도 전체 높이를 뷰포트 단위로 지정해주었고, 최소의 높이를 지정하여주었다.
```javascript
// MyPagPreferCar.js
<div className="w-full h-[45vh] min-h-[450px] mt-20">
```
<br>

사용자의 이용 내역을 보여주는 UI 경우에는 내부 요소들이 단순 텍스트, 버튼, 내부 컨테이너와 그에 포함되어있는 카드뷰 그 안에는 이미지, 태그 등 다양한 요소들로 구성되어있다. 따라서, 가로의 길이를 vh 단위가 아닌 픽셀 단위로 고정시켜주었다. 따라서, 별도로 최소 수치를 지정해줄 필요는 없다.
```javascript
// MyPagRecord.js
<div className="w-full mt-20 h-[980px]">
```
<br>

사용자의 면허 정보를 보여주는 UI 경우에는 컨텐츠들 중에서 가장 간단한 구조를 가지고 있다. 따라서, 전체 높이를 뷰포트 단위로 지정해주고 최소의 높이를 지정해주었다.
```javascript
// MyPagLicense.js
<div className="w-full mt-20 h-[70vh] min-h-[720px]">
```
<br>

마지막으로, 사용자의 계정 관리 UI 경우에는 구조는 간단하나, 버튼들이 포함되어있기에, 버튼의 높이를 고려하여야 한다. 또한, 제일 하단에 배치되어있는 컨텐츠이며 현재 웹사이트에 별다른 footer 가 포함되어있지 않아서 화면에서 보여지는 위치가 다른 컨텐츠들에 비해 불리하다고 판단하였다. 결국 간단한 구조이며, 많은 요소가 포함된 것은 아니지만, 고정된 수치로 지정하여주었다.
```javascript
// MyPagAccount.js
<div className="w-full mt-20 h-[350px]">
```
<br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [ ] 뷰포트와 최소 수치로 비율이 변경되는 컨텐츠들의 조정 적용 확인
- [ ] 고정된 높이를 갖는 컨텐츠들의 높이가 정상적으로 고정되는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

전체화면인 1920x1080 에서 보여지는 화면
![1080](https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/2e11af80-dc8f-4d15-8b2e-7622391dd532)

높이를 800 으로 줄인 결과에서 보여지는 화면
![800](https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/2d5d4f6f-a043-490a-b05d-aa5e05ebab83)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #26 
close #26 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference
없음.
<!-- 자신이 참조한 정보의 출처를 적는다. -->
