### PR TITLE
[Feat/#29] 홈 화면의 시간, 지점 검색 컴포넌트가 접혀있을 경우의 UI 구현

### DIFF
--- a/src/pages/home/homeSelectLocation/HomeSelectLocation.js
+++ b/src/pages/home/homeSelectLocation/HomeSelectLocation.js
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { LocationList } from "./internalComponents/LocationList";
 import { Map } from "./internalComponents/Map";
 import { TimeSelectForm } from "./internalComponents/TimeSelectForm";
+import listShowIcon from "../../../assets/listShowIcon.png";
 
 /**
  * 홈 화면에서 이용 시간, 지점을 선택하는 기능을 하는 컴포넌트
  * @param {string} props.width 부모에게 받아온 넓이값 (tailwind 속성)
  * @param {string} props.height 부모에게 받아온 높이값 (tailwind 속성)
+ * @param {boolean} props.isFold 부모에게 받아온 접힘, 닫힘 여부
  */
 function HomeSelectLocation(props) {
   /* 컴포넌트의 초기 설정 */
@@ -31,67 +33,137 @@ function HomeSelectLocation(props) {
     time: "14:00",
   });
 
-  return (
-    <>
-      <div className={initSetting}>
-        <div className="flex flex-col items-center justify-start w-full h-full overflow-y-scroll bg-white">
-          {/* 날짜 시간 선택 컴포넌트 */}
-          <div className="flex flex-row justify-between mx-5 w-[96%] mt-3">
-            <TimeSelectForm
-              width="w-[49%]"
-              legend="시작 시간"
-              setDateTime={setStartTime}
-            ></TimeSelectForm>
+  let [isFold, setIsFold] = useState(props.isFold);
 
-            <TimeSelectForm
-              width="w-[49%]"
-              legend="종료 시간"
-              setDateTime={setEndTime}
-            ></TimeSelectForm>
-          </div>
-
-          <div className="flex flex-row justify-between mx-5 w-[96%] mt-8 flex-grow">
-            {/*! 지도 컴포넌트는 svg 크기 조절 문제로 인해 크기가 일정수준 정해져 있음 */}
-
-            <Map
-              setStoreLocList={setStoreLocList}
-              setLocation={setLocation}
-            ></Map>
-
-            <div className="flex flex-col items-center justify-start w-[49%] max-h-[600px]">
-              {/* 지점 컴포넌트 */}
-              <LocationList
-                width="w-full"
-                height="h-[70%]"
-                storeLocInfo={storeLocList}
-                setSelectedStore={setSelectedStore}
-              ></LocationList>
-
-              <div className="flex flex-row items-center justify-around h-[30%] w-full">
-                {/* 리마인더 */}
-                <div className="flex flex-col justify-center font-bold text-l text-amber-700">
-                  <div className="mb-1 text-3xl text-amber-500">{location}</div>
-                  <div className="mb-3 text-3xl text-blue-500">
-                    {selectedStore}
-                  </div>
-                  <div>
-                    시작 시간 : {startTime.date} / {startTime.time}
-                  </div>
-                  <div>
-                    종료 시간 : {endTime.date} / {endTime.time}
-                  </div>
+  if (isFold) {
+    return (
+      <>
+        <div className={props.width + " h-[120px]"}>
+          <div className="flex flex-row items-center justify-around h-full bg-white">
+            <div className="w-[28%] h-[100px] bg-white">
+              {/* 고정 시작 시간 */}
+              <div className="relative flex justify-around items-center border-[5px] border-dashed border-slate-200 h-full">
+                <span className="absolute text-[1.5rem] px-4 left-2 top-[-24px] h-fit bg-white text-slate-600 font-extrabold">
+                  시작 시간
+                </span>
+                <div className="border-blue-500 border-[2px] rounded-full h-fit bg-sky-50 py-3 px-6 font-extrabold text-xl">
+                  {startTime.date}
                 </div>
+                <div className="border-blue-500 border-[2px] rounded-full h-fit bg-sky-50 py-3 px-6 font-extrabold text-xl">
+                  {startTime.time}
+                </div>
+              </div>
+            </div>
+            <div className="w-[28%] h-[100px] bg-white">
+              {/* 고정 종료 시간 */}
+              <div className="relative flex justify-around items-center border-[5px] border-dashed border-slate-200 h-full ">
+                <span className="absolute text-[1.5rem] px-4 left-2 top-[-24px] h-fit bg-white text-slate-600 font-extrabold">
+                  종료 시간
+                </span>
+                <div className="border-blue-500 border-[2px] rounded-full h-fit bg-sky-50 py-3 px-6 font-extrabold text-xl">
+                  {endTime.date}
+                </div>
+                <div className="border-blue-500 border-[2px] rounded-full h-fit bg-sky-50 py-3 px-6 font-extrabold text-xl">
+                  {endTime.time}
+                </div>
+              </div>
+            </div>
+            <div className="w-[28%] h-[100px] bg-sky-50 rounded-lg border-[2px] border-blue-500">
+              {/* 지점 위치 */}
+              <div className="flex flex-col items-center justify-center h-full">
+                <div className="text-2xl font-extrabold text-amber-500">
+                  {location}
+                </div>
+                <div className="text-3xl font-extrabold text-blue-500 ">
+                  {selectedStore}
+                </div>
+              </div>
+            </div>
+            <div className="w-[10%] flex justify-center ">
+              <button>
+                <img
+                  src={listShowIcon}
+                  alt="unfold"
+                  onClick={() => {
+                    setIsFold(false);
+                  }}
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <div className={initSetting}>
+          <div className="flex flex-col items-center justify-start w-full h-full overflow-y-scroll bg-white">
+            {/* 날짜 시간 선택 컴포넌트 */}
+            <div className="flex flex-row justify-between mx-5 w-[96%] mt-3">
+              <TimeSelectForm
+                width="w-[49%]"
+                legend="시작 시간"
+                setDateTime={setStartTime}
+              ></TimeSelectForm>
 
-                <button className="bg-rose-500 w-1/2 h-1/2 rounded-2xl text-[40px] text-white font-black">
-                  검색하기
-                </button>
+              <TimeSelectForm
+                width="w-[49%]"
+                legend="종료 시간"
+                setDateTime={setEndTime}
+              ></TimeSelectForm>
+            </div>
+
+            <div className="flex flex-row justify-between mx-5 w-[96%] mt-8 flex-grow">
+              {/*! 지도 컴포넌트는 svg 크기 조절 문제로 인해 크기가 일정수준 정해져 있음 */}
+
+              <Map
+                setStoreLocList={setStoreLocList}
+                setLocation={setLocation}
+              ></Map>
+
+              <div className="flex flex-col items-center justify-start w-[49%] max-h-[600px]">
+                {/* 지점 컴포넌트 */}
+                <LocationList
+                  width="w-full"
+                  height="h-[70%]"
+                  storeLocInfo={storeLocList}
+                  setSelectedStore={setSelectedStore}
+                ></LocationList>
+
+                <div className="flex flex-row items-center justify-around h-[30%] w-full">
+                  {/* 리마인더 */}
+                  <div className="flex flex-col justify-center font-bold text-l text-amber-700">
+                    <div className="mb-1 text-3xl text-amber-500">
+                      {location}
+                    </div>
+                    <div className="mb-3 text-3xl text-blue-500">
+                      {selectedStore}
+                    </div>
+                    <div>
+                      시작 시간 : {startTime.date} / {startTime.time}
+                    </div>
+                    <div>
+                      종료 시간 : {endTime.date} / {endTime.time}
+                    </div>
+                  </div>
+
+                  <button
+                    className="bg-rose-500 w-1/2 h-1/2 rounded-2xl text-[40px] text-white font-black"
+                    onClick={() => {
+                      setIsFold(true);
+                    }}
+                  >
+                    검색하기
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </>
-  );
+      </>
+    );
+  }
 }
 
 export { HomeSelectLocation };


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

홈 화면에서, 시간과 지점을 검색하는 컴포넌트는 검색하기 버튼을 눌렀을 경우
다음 페이지로 넘어가며 작은 형태로 접혀야 한다. 이를 구현하였다.
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

<br><br>

## 🥥 Contents

### isFold State를 사용하여 상황별로 다른 렌더링 구현

---

``` jsx
let [isFold, setIsFold] = useState(props.isFold);

if (isFold) {
... 접혀있는 UI
} else {
... 펴져있는 UI
}

```
- isFold State를 선언하여 접힌 UI와 펴진 UI를 분기별로 보여줄 수 있도록 구현하였다.
- isFold State는 props.isFold로 초기화되는데, 이는 부모가 컴포넌트를 호출할 때 어떤 화면을 기본 화면으로 설정할지에 따라 달라진다.

<br><br>

### onclick 함수에 화살표 함수를 사용하여 isFold State를 업데이트

---

코드가 렌더링 될 경우, onclick 함수가 실행이 되는데 setIsFold(true), setIsFold(false) 두 코드가 모두 한 컴포넌트 안에 존재하기 때문에 계속 상태값이 바뀌어 too many render 오류가 생기게 된다.

<br>

이 경우, 화살표 함수를 사용하면 해결이 된다.
자세한 내용은 추후 위키에 적도록 하겠다. 아직 이해를 못 했기 때문이다.

<br><br>

## 🧪 Testing

- [x] 넓은 화면에서 검색하기를 눌렀을 경우 컴포넌트가 접히는가?
- [x] 좁은 화면에서 화살표 아이콘을 눌렀을 경우 컴포넌트가 펴지는가?
- [x] 넓은 화면에서 지역과, 지점을 고른 후 검색하기를 눌렀을 경우 좁은 화면에도 반영이 되는가?

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

<br><br>

## 📸 Screenshot
![prTest](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/e481fc38-44f4-4ae2-a360-d1c1200a8f19)

<br><br>

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

close #29 

- #29 



<br><br>
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

- 화살표 함수와 렌더링 반복 오류 : https://sigorzav.github.io/posts/React-ID2301002/

<br><br>
<!-- 자신이 참조한 정보의 출처를 적는다. -->
