### PR TITLE
[Feat/#25] 홈 화면 차량 조회 UI 구현

### DIFF
--- a/src/pages/home/homeInquireCar/HomeInquireCar.js
+++ b/src/pages/home/homeInquireCar/HomeInquireCar.js
@@ -1,0 +1,67 @@
+import { HomeSelectLocation } from "../homeSelectLocation/HomeSelectLocation";
+import { HomeSearchPreferOption } from "./homeSearchPreferOption/HomeSearchPreferOption";
+import { useState } from "react";
+import CarCard from "../../myPage/myPageRecord/internalComponents/CarCard";
+import { HomeNotice } from "./homeNotice/HomeNotice";
+
+/**
+ * 차량의 옵션을 선택하고, 옵션에 맞는 차량과 공지사항을 제공하는 컴포넌트.
+ */
+function HomeInquireCar(props) {
+  let [carInfo, setCarInfo] = useState([
+    ["차1", "11일 1111", "11111", "11111"],
+    ["차2", "22이 2222", "22222", "22222"],
+    ["차3", "33삼 3333", "33333", "33333"],
+    ["차5", "55오 5555", "55555", "55555"],
+    ["차5", "55오 5555", "55555", "55555"],
+    ["차5", "55오 5555", "55555", "55555"],
+    ["차5", "55오 5555", "55555", "55555"],
+  ]);
+
+  const titleArray = [
+    "글1",
+    "좀 긴 글 글글그ㅡ르르그ㅡ르ㅡㅡ그르ㅡ글",
+    "글 3",
+    "글 4",
+  ];
+
+  return (
+    <>
+      <div className="w-[1200px] pt-[calc(80px+2vh)]">
+        <div className="flex flex-col mb-5">
+          <div className="mb-5">
+            <HomeSelectLocation
+              width="w-[1200px]"
+              height="h-[calc(96vh-80px)]"
+              isFold={true}
+            ></HomeSelectLocation>
+          </div>
+          <div className="flex justify-between">
+            <div className="flex w-[75%] flex-wrap min-h-[680px] max-h-[900px] h-[calc(98vh-240px)] bg-white overflow-y-scroll">
+              {carInfo.map((val, idx) => {
+                return <CarCard carInfo={val}></CarCard>;
+              })}
+            </div>
+            <div className="flex flex-col w-[23%] min-h-[680px] h-[calc(98vh-240px)] justify-between max-h-[900px]">
+              <div className=" bg-white w-full h-[60%]">
+                <HomeSearchPreferOption
+                  width="w-full"
+                  height="h-full"
+                ></HomeSearchPreferOption>
+              </div>
+              <div className=" bg-white w-full h-[37%]">
+                <HomeNotice
+                  width="w-full"
+                  height="h-full"
+                  titleArray={titleArray}
+                ></HomeNotice>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export { HomeInquireCar };

--- a/src/pages/home/homeInquireCar/homeNotice/HomeNotice.js
+++ b/src/pages/home/homeInquireCar/homeNotice/HomeNotice.js
@@ -1,0 +1,37 @@
+/**
+ * 홈에서 공지사항을 띄워 주는 컴포넌트.
+ * 부모는 반드시 제목 배열을 넘겨줘야 한다.
+ * @param {string} props.width 부모에게서 받아온 넓이 (tailwind 속성)
+ * @param {string} props.height 부모에게서 받아온 높이 (tailwind 속성)
+ * @param {[string]} props.titleArray 부모에게서 받아온 공지사항의 제목 배열
+ */
+function HomeNotice(props) {
+  const initSetting = props.width + " " + props.height;
+  return (
+    <div className={initSetting}>
+      <div className="relative flex flex-col items-center justify-around h-full">
+        <div className="mt-3 w-2/4 text-center px-4 py-1 border-dashed rounded-md border-slate-200 border-[4px] font-extrabold text-xl">
+          공지사항
+        </div>
+        <div className="border-blue-500 h-2/3 border-[3px] w-[90%] rounded-2xl m-3 overflow-hidden ">
+          {props.titleArray.map((elm, idx) => {
+            return (
+              <div className="flex justify-center w-full my-1 h-[22%]">
+                <div className="text-center border-[3px] py-1 border-slate-300 bg-slate-100 w-[90%] text-xl font-extrabold rounded-md flex-nowrap overflow-hidden whitespace-nowrap text-ellipsis">
+                  {elm}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <button className="absolute top-0 right-0 text-sm">
+          더보기{">"}
+          {">"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export { HomeNotice };

--- a/src/pages/home/homeInquireCar/homeSearchPreferOption/HomeSearchPreferOption.js
+++ b/src/pages/home/homeInquireCar/homeSearchPreferOption/HomeSearchPreferOption.js
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { SelectList } from "./internalComponents/SelectList";
+
+/**
+ * 차량의 옵션을 선택하는 컴포넌트.
+ * @param {string} props.width 부모에게서 받아온 넓이. (tailwind 속성)
+ * @param {string} props.height 부모에게서 받아온 높이. (tailwind 속성)
+ */
+function HomeSearchPreferOption(props) {
+  const initSetting = props.width + " " + props.height;
+
+  /* 이후 다양한 옵션들을 추가할 예정 */
+  const carSizeArray = ["big", "middle", "small"];
+  let [selectedCarSize, setSelectedCarSize] = useState("big");
+
+  return (
+    <div className={initSetting}>
+      <div className="flex justify-center w-full h-full">
+        <div className="flex flex-col items-center justify-around text-xl font-extrabold">
+          <button className="w-full px-6 py-2 text-white rounded-md bg-rose-500">
+            사용자 선호 차량 검색
+          </button>
+          <div className="w-3/4 text-center px-4 py-1 border-dashed rounded-md border-slate-200 border-[4px]">
+            차량 옵션 선택
+          </div>
+
+          <SelectList
+            listArray={carSizeArray}
+            selectedSetter={setSelectedCarSize}
+          >
+            {selectedCarSize}
+          </SelectList>
+
+          <SelectList
+            listArray={carSizeArray}
+            selectedSetter={setSelectedCarSize}
+          >
+            {selectedCarSize}
+          </SelectList>
+
+          <SelectList
+            listArray={carSizeArray}
+            selectedSetter={setSelectedCarSize}
+          >
+            {selectedCarSize}
+          </SelectList>
+
+          <SelectList
+            listArray={carSizeArray}
+            selectedSetter={setSelectedCarSize}
+          >
+            {selectedCarSize}
+          </SelectList>
+
+          <SelectList
+            listArray={carSizeArray}
+            selectedSetter={setSelectedCarSize}
+          >
+            {selectedCarSize}
+          </SelectList>
+
+          <button className="w-full px-6 py-2 text-white rounded-md bg-rose-500">
+            선택 옵션 차량 검색
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { HomeSearchPreferOption };

--- a/src/pages/home/homeInquireCar/homeSearchPreferOption/internalComponents/SelectList.js
+++ b/src/pages/home/homeInquireCar/homeSearchPreferOption/internalComponents/SelectList.js
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+/**
+ * 클릭하면 여러가지를 선택할 수 있는 리스트 셀렉터 컴포넌트.
+ * 부모는 반드시 setter를 첨부하여 사용자가 리스트에서 무엇을 선택했는지 알 수 있도록 해야 한다.
+ * @param {[string]} props.listArray 부모에게서 받아온 리스트의 목록
+ * @param {setter} props.selectedSetter 부모에게서 받아온 setter
+ */
+function SelectList(props) {
+  let [selectedElm, setSelectedElm] = useState(props.listArray[0]);
+  let [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <button
+      className="relative w-full px-6 py-1 border-[2px] border-blue-500 rounded-full bg-sky-50"
+      onClick={() => {
+        setIsVisible(!isVisible);
+      }}
+    >
+      {selectedElm}
+
+      {isVisible ? (
+        <div className="z-40 top-[-2px] rounded-2xl left-[-2px] absolute w-[calc(100%+4px)] px-6 py-1 border-[2px] items-center border-blue-500 bg-sky-50 flex flex-col">
+          {props.listArray.map((elm, idx) => {
+            return (
+              <button
+                className="py-1 w-fit h-fit hover:bg-blue-500"
+                onClick={() => {
+                  setSelectedElm(elm);
+                  props.selectedSetter(elm);
+                }}
+              >
+                {props.listArray[idx]}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </button>
+  );
+}
+
+export { SelectList };


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

홈 화면 차량 조회 UI를 구현하였다.
구성 요소에는, 날짜와 시간 선택, 차량 카드뷰, 선호 차량 검색, 공지사항 등이 포함되어 있다.

<br><br>

## 🥥 Contents

### 선호 차량 리스트의 구현

---

선호 차량 리스트 컴포넌트는 2가지의 props를 받아야 한다.
1. 클릭했을 경우 펼쳐질 리스트들의 목록 -> props.listArray
2. 어떤 항목을 선택했는지 변경하는 setter -> props.selectedSetter

<br>

선호 차량 리스트 컴포넌트 내부에는 2가지의 state가 존재한다.

``` jsx
let [selectedElm, setSelectedElm] = useState(props.listArray[0]); // 선택된 항목을 표시하기 위함.
let [isVisible, setIsVisible] = useState(false); // 리스트가 보이는지 보이지 않는지 체크한다.
```

<br> 
<br> 
<br> 



### 리스트의 표시 방법

```jsx
{isVisible ? (리스트가 펼쳐진 모습) : null}
```
- isVisible이 true가 아닌 경우 리스트는 보이지 않는다.

<br><br><br>

### 리스트 항목 교체의 처리

```js
{props.listArray.map((elm, idx) => {
  return (
    <button
      className="..."
      onClick={() => {
        setSelectedElm(elm); // 선택된 항목을 교체한다.
        props.selectedSetter(elm); // setter를 통해 항목이 교체되었다는 사실을 상위 컴포넌트에게도 알린다.
      }}
    >
      {props.listArray[idx]}
    </button>
  );
})}
```
- 현재 컴포넌트 내부에서 항목의 교체를 하는 코드는 setSelectedElm() 이다.
- 상위 컴포넌트에게 항목의 교체를 알리는 코드는 props.selectedSetter() 이다.

<br><br>




## 🧪 Testing

- [x] 시간, 장소 선택 컴포넌트가 정상적으로 작동한다.
- [x] 차량 카드뷰 리스트가 정상적으로 작동한다.
- [x] 사용자 선호 차량 컴포넌트의 리스트가 정상적으로 작동한다.
- [x] 공지사항이 정상적으로 보여진다.

<br><br>

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
![test1](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/f0420e12-1e74-49c9-8b22-c16d484992bf)
![test2](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/8db3bbbd-2582-4a94-9f8f-c450a610127b)
![test3](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/f66702a6-f2a2-4427-8984-ceae56f0afbe)

<br><br>
## ⚓ Related Issue

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

close #25 

- #25 

<br><br>
## 📚 Reference
none
<br><br>
<!-- 자신이 참조한 정보의 출처를 적는다. -->
