### PR TITLE
[Feat/#37] 마이페이지 라우터 및 Nav 링크 설정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,16 @@
-import logo from "./logo.svg";
 import "./App.css";
-import Nav from "./components/Nav";
+import { Routes, Route } from "react-router-dom";
+import { Nav } from "./components/Nav";
+import { MyPage } from "./pages/myPage/MyPage";
 
 function App() {
   return (
     <>
-      <div className="flex-col items-center justify-between w-full h-full bg-slate-200">
-        <Nav name="홍길동" />
+      <div className="w-full h-full bg-slate-200">
+        <Nav />
+        <Routes>
+          <Route path="/mypage" element={<MyPage />}></Route>
+        </Routes>
       </div>
     </>
   );

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,7 +1,9 @@
 import React from "react";
 import logo from "../assets/Logo.png";
+import { useNavigate } from "react-router-dom";
 
 function Nav(props) {
+  let nav = useNavigate();
   return (
     <>
       <div className="fixed top-0 left-0 right-0 flex justify-between w-screen border-b-[1px] h-20 bg-sky-100 border-slate-600">
@@ -18,7 +20,7 @@ function Nav(props) {
         <div className="flex items-center w-1/4 h-full mr-5">
           <ul className="flex justify-between w-full text-lg font-semibold list-none">
             <li>고객센터</li>
-            <li>마이페이지</li>
+            <li onClick={() => nav("/mypage")}>마이페이지</li>
             <li>
               <span className="text-amber-700">{props.name}</span> 고객님
               안녕하세요!
@@ -30,4 +32,4 @@ function Nav(props) {
   );
 }
 
-export default Nav;
+export { Nav };

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -1,0 +1,9 @@
+function Home() {
+  return (
+    <>
+      <div></div>
+    </>
+  );
+}
+
+export { Home };


### PR DESCRIPTION
마이페이지 라우터 설정
 - App.js 에서 MyPage 라우터 설정
 - /mypage

Nav 마이페이지 링크 설정
 - "마이페이지" 버튼 클릭시 마이페이지로 이동
 - Link to "/mypage"

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

- 마이페이지 라우터 설정
- Nav 마이페이지 링크 설정

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

### 마이페이지 라우터 설정
App.js 에서 라우터를 통해 호출될 페이지들 중 마이페이지를 설정하였다.
```javascript
// App.js
<Routes>
          <Route path="/mypage" element={<MyPage />}></Route>
</Routes>
```
<br>

### Nav "마이페이지" 버튼 링크 설정
네비게이션 바에는 "마이페이지" 버튼이 존재한다. 이 버튼을 누르게 되면 마이페이지 화면으로 이동하도록 설정하였다.
```javascript
// Nav.js
import { useNavigate } from "react-router-dom";

function Nav() {
   let nav = useNavigate();

   return (
                ...
                <li onClick={() => nav("/mypage")}>마이페이지</li>
                ...
```
react-router-dom 라이브러리가 지원하는 useNavigate 를 사용하였다. Link 와 같은 기능을하며 useNavigate 함수를 할당받을 변수를 선언하고 매개변수로 마이페이지의 path 인 "/mypage" 를 전달해주었다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 마이페이지 라우터 설정 적용 확인
- [x] Nav 마이페이지 이동 적용 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 라우터 마이페이지 이동
![라우팅](https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/82974bff-1eaa-4d17-b34e-adfd014cd6ae)
<br>

### Nav 마이페이지 이동
![nav](https://github.com/YU-RentCar/yurentcar-fe-web/assets/86611398/f9fd9f69-11b4-418a-89a6-6267e8efe598)
<br>

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #37 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

코딩애플 리액트 라우터
<!-- 자신이 참조한 정보의 출처를 적는다. -->
