### PR TITLE
[Feat/#44] 로그인 로직 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,36 @@
 import "./App.css";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useNavigate } from "react-router-dom";
 import { Nav } from "./components/Nav";
 import { MyPage } from "./pages/myPage/MyPage";
 import { Home } from "./pages/home/Home";
 import { HomeInquireCar } from "./pages/home/homeInquireCar/HomeInquireCar";
+import { Auth } from "./pages/auth/Auth";
+import axios from "axios";
+import { useEffect } from "react";
 
 function App() {
+  let nav = useNavigate();
+
+  useEffect(() => {
+    axios
+      .get("/users/profiles?username=", {
+        withCredentials: true,
+      })
+      .then(function (response) {
+        console.log(response);
+      })
+      .catch(function (error) {
+        nav("/auth");
+      });
+  }, []);
+
   return (
     <>
       <div className="w-full h-[100vh]">
         <div className="fixed top-0 left-0 w-full h-full bg-slate-200 -z-50"></div>
         <Nav />
         <Routes>
+          <Route path="/auth" element={<Auth />}></Route>
           <Route path="/mypage" element={<MyPage />}></Route>
           <Route path="/home" element={<Home />}>
             <Route

--- a/src/App.js
+++ b/src/App.js
@@ -13,14 +13,27 @@ function App() {
 
   useEffect(() => {
     axios
-      .get("/users/profiles?username=", {
-        withCredentials: true,
-      })
+      .post(
+        "http://localhost:8080/api/v1/auth/user-info",
+        {},
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          withCredentials: true,
+        }
+      )
       .then(function (response) {
         console.log(response);
+        if (response.status === 200) {
+          nav("/home");
+        }
       })
       .catch(function (error) {
-        nav("/auth");
+        console.log(error.response);
+        if (error.response.status === 401) {
+          nav("/auth");
+        }
       });
   }, []);
 

--- a/src/pages/auth/Auth.js
+++ b/src/pages/auth/Auth.js
@@ -7,7 +7,7 @@ function Auth() {
     <div className="flex flex-col items-center justify-center w-[1200px] h-[100vh] overflow-x-hidden mx-auto">
       <img src={Logo} alt="logo" className="object-contain w-1/3 h-1/5"></img>
       <div className="w-1/3 h-1/5">
-        <a href="http:/yurentcar.kro.kr:8080/oauth2/authorization/naver">
+        <a href="http://yurentcar.kro.kr:8080/oauth2/authorization/naver">
           <img
             src={Naver}
             alt="naver"
@@ -16,7 +16,7 @@ function Auth() {
         </a>
       </div>
       <div className="w-1/3 h-1/5">
-        <a href="http:/yurentcar.kro.kr:8080/oauth2/authorization/kakao">
+        <a href="http://yurentcar.kro.kr:8080/oauth2/authorization/kakao">
           <img
             src={Kakao}
             alt="kakao"

--- a/src/pages/auth/Auth.js
+++ b/src/pages/auth/Auth.js
@@ -7,7 +7,7 @@ function Auth() {
     <div className="flex flex-col items-center justify-center w-[1200px] h-[100vh] overflow-x-hidden mx-auto">
       <img src={Logo} alt="logo" className="object-contain w-1/3 h-1/5"></img>
       <div className="w-1/3 h-1/5">
-        <a href="http://yurentcar.kro.kr:8080/oauth2/authorization/naver">
+        <a href="http://localhost:8080/oauth2/authorization/naver">
           <img
             src={Naver}
             alt="naver"

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,25 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, createSlice } from "@reduxjs/toolkit";
+
+/**
+ * 유저의 정보를 담고 있는 state
+ *
+ * 사용 컴포넌트
+ * Home
+ */
+let userInfo = createSlice({
+  name: "userInfo",
+  initialState: {},
+  reducers: {
+    changeUserInfo(state) {
+      return state;
+    },
+  },
+});
 
 export default configureStore({
-  reducer: {},
+  reducer: {
+    userInfo: userInfo.reducer,
+  },
 });
+
+export let { changeUserInfo } = userInfo.actions;


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

사용자가 로그인을 하였을 경우와 하지 않았을 경우를 나누어, 처리하는 로직을 구현하였다.
사용자가 로그인을 하지 않았을 경우, 로그인 페이지로 강제 이동한다.
사용자가 로그인을 하였거나, 이전에 했던 경우 홈 페이지로 이동한다.
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

<br><br>
## 🥥 Contents

### 사용자 로그인 분기 추가

---

``` js
useEffect(() => {
  axios
    .post(
      "http://localhost:8080/api/v1/auth/user-info",
      {},
      {
        headers: {
          "Content-Type": "application/json",
        },
        withCredentials: true,
      }
    )
    .then(function (response) {
      console.log(response);
      if (response.status === 200) {
        nav("/home");
      }
    })
    .catch(function (error) {
      console.log(error.response);
      if (error.response.status === 401) {
        nav("/auth");
      }
    });
}, []);
```
- 사이트에 접속하자마자 useEffect로 함수가 실행되어, 처음에 바로 내부 함수가 실행된다.
- post 요청으로 사용자 정보를 받아온다. 
- 사용자 정보가 없으면, 401이 오고, 로그인 화면으로 강제이동한다.
- 사용자 정보가 있으면, 200이 오고, 홈 화면으로 강제이동한다.

<br><br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 쿠키에 토큰이 들어오는 것을 확인한다.
- [x] 사용자가 로그인을 하지 않았을 경우 로그인 화면으로 강제이동한다.
- [x] 사용자가 로그인을 하였을 경우 홈 화면으로 강제이동한다.

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->
<br><br>


## 📸 Screenshot
![test1](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/32bfc9cf-87d8-4f4d-9a73-a3bf8111954f)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->
<br><br>

## ⚓ Related Issue

- closes #44
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

<br><br>

## 📚 Reference
axios 공식문서 번역본 : https://yamoo9.github.io/axios/

<br><br>
<!-- 자신이 참조한 정보의 출처를 적는다. -->
