### PR TITLE
[Feat/#62] 서버로부터 지점 리스트를 받아오는 기능 추가

### DIFF
--- a/src/api/HomeAxios.js
+++ b/src/api/HomeAxios.js
@@ -1,0 +1,15 @@
+import { api } from "./interceptors";
+
+/* 지점 리스트  */
+let getStoreList = (province) => {
+  return api({
+    url: "/branches",
+    method: "get",
+
+    params: {
+      siDo: province,
+    },
+  });
+};
+
+export { getStoreList };

--- a/src/pages/home/homeSelectLocation/internalComponents/Map.js
+++ b/src/pages/home/homeSelectLocation/internalComponents/Map.js
@@ -1,4 +1,4 @@
-import { React, useEffect, useState } from "react";
+import { React, useState } from "react";
 import { ReactComponent as MapSVG } from "../../../../assets/Map.svg";
 import { getStoreList } from "../../../../api/HomeAxios";
 /**
@@ -38,27 +38,18 @@ function Map(props) {
     let provinceName = provinceList[Number(e.target.id)];
     if (e.target.id !== "layer_1") {
       props.setLocation(provinceList[Number(e.target.id)]);
-
       /* 아래 내용은 서버와의 통신을 구현해둔 내용 */
 
       (async () => {
         await getStoreList(provinceName)
           .then((response) => {
             console.log(response.data);
+            props.setStoreLocList(response.data);
           })
           .catch((error) => {
             console.log(error.response);
           });
       })();
-
-      props.setStoreLocList([
-        "울산삼산점",
-        "옥동점",
-        "방어진점",
-        "반구동점",
-        "명촌점",
-        "진장점",
-      ]);
     }
   };
 
@@ -75,20 +66,6 @@ function Map(props) {
       setMapLocation(provinceList[Number(e.target.id)]);
     }
   };
-
-  /* state mapLocation 이 변경되면, 내부 함수가 실행된다.
-    이 내부 코드는 지도 클릭 후에도 푸른색으로 선택 지역을 유지시키기 위한 코드이다.
-  */
-  useEffect(() => {
-    let elms = document.querySelectorAll(".st0");
-    elms.forEach((elm) => {
-      if (elm.id === mapLocation) {
-        elm.classList.add("selected");
-      } else {
-        elm.classList.remove("selected");
-      }
-    });
-  }, [mapLocation]);
 
   return (
     <div

--- a/src/pages/home/homeSelectLocation/internalComponents/Map.js
+++ b/src/pages/home/homeSelectLocation/internalComponents/Map.js
@@ -1,6 +1,6 @@
 import { React, useEffect, useState } from "react";
 import { ReactComponent as MapSVG } from "../../../../assets/Map.svg";
-
+import { getStoreList } from "../../../../api/HomeAxios";
 /**
  * 지도를 출력하고 지도의 상호작용이 설정된 컴포넌트
  * @param {setter} props.setStoreLocList 부모에게 받아온 점포 위치 리스트를 바꾸는 setter
@@ -35,11 +35,22 @@ function Map(props) {
    */
   let callStoreInfo = function (e) {
     /* 지도 밖의 배경에 클릭을 하면 배경의 id 인 layer_1 지역으로 표시되는 것을 막기 위함. */
+    let provinceName = provinceList[Number(e.target.id)];
     if (e.target.id !== "layer_1") {
       props.setLocation(provinceList[Number(e.target.id)]);
 
-      /* 아래 내용은 추후 서버와의 통신을 임시로 구현해둔 내용 */
-      alert(e.target.id + " ajax calling");
+      /* 아래 내용은 서버와의 통신을 구현해둔 내용 */
+
+      (async () => {
+        await getStoreList(provinceName)
+          .then((response) => {
+            console.log(response.data);
+          })
+          .catch((error) => {
+            console.log(error.response);
+          });
+      })();
+
       props.setStoreLocList([
         "울산삼산점",
         "옥동점",


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

사용자가 지도의 지역을 클릭할 경우, 서버로부터 해당 지역의 지점 리스트를 받아와 사용자에게 보여주는 기능을 구현
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

<br><br>

## 🥥 Contents

## 지점 리스트 업데이트
사용자가 지도의 지역을 클릭할 경우, 기존에는 존재하던 더미 데이터가 그 자리를 차지했지만, 코드 추가로 불러온 데이터를 리스트로 가져온다.

```js
/* 지점 리스트  */
let getStoreList = (province) => {
  return api({
    url: "/branches",
    method: "get",

    params: {
      siDo: province,
    },
  });
};
```

- 서버에 지점 리스트를 요청하는 axios 코드이다.

```js
(async () => {
  await getStoreList(provinceName)
    .then((response) => {
      console.log(response.data);
      props.setStoreLocList(response.data);
    })
    .catch((error) => {
      console.log(error.response);
    });
})();
```

- props.setStoreLocList 를 통해 사용자에게 보이는 지점 리스트를 변경한다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

<br><br>

## 🧪 Testing

- [x] 서버에서 지역에 맞는 지점 리스트를 성공적으로 불러온다.
- [x] 서버에서 불러온 지점 리스트를 사용자에게 성공적으로 보여준다.

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

<br><br>

## 📸 Screenshot
![test1](https://github.com/YU-RentCar/yurentcar-fe-web/assets/54520200/ec05d999-dfcd-4e59-9e01-155927c0bb86)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

<br><br>

## ⚓ Related Issue

Close #62 
- close #62
- 閉じる #62

<br>

Please close please

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

<br><br>

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->

<br><br>
